### PR TITLE
Match common editor highlighters more closely.

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -12,30 +12,38 @@ function hljsDefineGraphQL(hljs) {
     aliases: ["gql"],
     keywords: {
       keyword:
-        "query mutation subscription|10 type interface union scalar fragment|10 enum on ...",
-      literal: "true false null"
+        "query mutation subscription|10 input schema implements type interface union scalar fragment|10 enum on ...",
+      literal: "ID ID! String Float Int Boolean",
+      variable: "true false null"
     },
     contains: [
       hljs.HASH_COMMENT_MODE,
       hljs.QUOTE_STRING_MODE,
       hljs.NUMBER_MODE,
       {
-        className: "type",
+        className: "literal",
         begin: "[^\\w][A-Z][a-z]",
         end: "\\W",
         excludeEnd: true
       },
       {
         className: "literal",
-        begin: "[^\\w][A-Z][A-Z]",
+        begin: ":\\s\\[",
+        end: "[\\]!]{1,3}",
+        excludeBegin: true,
+        excludeEnd: true
+      },
+      {
+        className: "type",
+        begin: "[^\\w](?!ID)[A-Z][A-Z]",
         end: "\\W",
         excludeEnd: true
       },
-      { className: "variable", begin: "\\$", end: "\\W", excludeEnd: true },
       {
-        className: "keyword",
-        begin: "[.]{2}",
-        end: "\\."
+        className: "name",
+        begin: "\\$",
+        end: "\\W",
+        excludeEnd: true
       },
       {
         className: "meta",


### PR DESCRIPTION
These rules more closely match (as examples) themes like VSCode Dark+, Atom One Dark Pro, etc.